### PR TITLE
Make uno jar work with java 8+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 .gradle
 **/out/
 /core/src/main/resources/.version
+/tests/.unojar/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ gradle shadow, this form of packaging does not intermix classes into a single di
 a degree of separation between libraries with distinct licensing concerns. I am not a Lawyer, and can't give 
 legal advice, but I feel that this method is much more consistent with LGPL license restrictions than shade/shadow 
 because the original distributed binary jar is maintained intact as distributed. Unpacking and fiddling with 
-package names  changes the work and (in my own, not a lawyer opinion) is clearly creating a derived work 
+package names changes the work and (in my own, not a lawyer opinion) is clearly creating a derived work 
 for which source code would need to be published. 
 
-Unlike capsule it does not want to extract jar files onto the user's filesystem, and is not normally hindered by
+Unlike capsule, it does not want to extract jar files onto the user's filesystem, and is not normally hindered by
 a lack of write access to the filesystem.
 
 This project is based on a fork of One-JAR by Simon Tuffs. Please be sure to see the NOTICE.txt file
@@ -23,7 +23,7 @@ User documentation can be found in our wiki: https://github.com/nsoft/uno-jar/wi
 ## Goals
 
 The original One-JAR project evolved in a time long before modern build frameworks. It has become 
-significantly out dated and is not actively maintained. For example it has facilities for
+significantly out dated and is not actively maintained. For example, it has facilities for
 creating an "SDK" that can be used to jump-start a project with it. Back in the early 2000's this
 was a popular pattern, but In this day and age it has become redundant with modern
 tools such as maven and gradle. These tools already have jump-starting capabilities via archetypes, and most IDE's 
@@ -31,7 +31,7 @@ will layout a standard project layout. Uno-jar will endeavor to carry forward th
 of One-JAR and leave behind the outdated features as much as possible. 
 
 The PRIMARY use case in all of this is to add an ant task, or gradle task to a build that packages an application
-into an executable "fat jar" that loads it's classes from distinct jar files contained within the final
+into an executable "fat jar" that loads its classes from distinct jar files contained within the final
 single distributable jar, that runs with a simple `java -jar` invocation. Facilities for unpacking this automatically 
 or the like are not likely to be supported going forward. The focus must be kept narrow so that the tool can remain 
 light and hopefully be more easily maintained. 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Uno-Jar
 
-Single jar packaging based on a JarClassLoader. Unlike maven shade and gradle shadow, this form of packaging
-does not intermix classes into a single directory, and thereby maintains a degree of separation between
-libraries with distinct licensing concerns. I am not a Lawyer, and can't give legal advice, but I feel that
-this method is much more consistent with LGPL license restrictions than shade/shadow because the original
-distributed binary jar is maintained intact as distributed. Unpacking and fiddling with package names 
-changes the work and (in my own, not a lawyer opinion) is clearly creating a derived work 
+Uno-Jar provides single executable jar ("fat-jar") packaging based on a JarClassLoader. Unlike maven shade and 
+gradle shadow, this form of packaging does not intermix classes into a single directory, and thereby maintains 
+a degree of separation between libraries with distinct licensing concerns. I am not a Lawyer, and can't give 
+legal advice, but I feel that this method is much more consistent with LGPL license restrictions than shade/shadow 
+because the original distributed binary jar is maintained intact as distributed. Unpacking and fiddling with 
+package names  changes the work and (in my own, not a lawyer opinion) is clearly creating a derived work 
 for which source code would need to be published. 
 
 Unlike capsule it does not want to extract jar files onto the user's filesystem, and is not normally hindered by
@@ -17,6 +17,7 @@ for the restrictions on using his code. The original project can be found at:
 http://one-jar.sourceforge.net/
 
 ## Documentation
+
 User documentation can be found in our wiki: https://github.com/nsoft/uno-jar/wiki
 
 ## Goals
@@ -27,8 +28,7 @@ creating an "SDK" that can be used to jump-start a project with it. Back in the 
 was a popular pattern, but In this day and age it has become redundant with modern
 tools such as maven and gradle. These tools already have jump-starting capabilities via archetypes, and most IDE's 
 will layout a standard project layout. Uno-jar will endeavor to carry forward the **basic** functionality
-of One-JAR and leave behind the outdated features as much as possible. Support for modern JVM's and new features such as 
-Multi-release jars (MRJars) will be added. 
+of One-JAR and leave behind the outdated features as much as possible. 
 
 The PRIMARY use case in all of this is to add an ant task, or gradle task to a build that packages an application
 into an executable "fat jar" that loads it's classes from distinct jar files contained within the final
@@ -36,31 +36,23 @@ single distributable jar, that runs with a simple `java -jar` invocation. Facili
 or the like are not likely to be supported going forward. The focus must be kept narrow so that the tool can remain 
 light and hopefully be more easily maintained. 
 
-Updating of builds, tests, code-style, and use of modern java constructs where beneficial will also be 
-conducted over time.
 
 ## Status
 
-### Working
-1. Core libraries for simple executable case.
-1. Ant task
-1. Gradle task
-1. Unit test validating execution of Uno-Jar-Main-Class, and access to lib
-1. Example of invoking the ant task from gradle
+Uno-Jar is now fully ready to use, it works with Java 11, but does not have any particular support for the Java 9+ 
+module system. Modular jars are expected to generally work or fail as they would on any other classpath, though
+this has not been extensively tested, and distribution of a fully modular application via uno-jar is untested.
+Uno-Jar does however support multi-release jars (a. k. a. MR jars) as libraries and correctly loads the appropriate
+classes for the JVM in use. Core and ant jars can be found on maven central here: 
+
+https://search.maven.org/search?q=g:com.needhamsoftware.unojar
+
+the gradle task can be found at 
+
+https://plugins.gradle.org/plugin/com.needhamsoftware.unojar
 
 ### Unsupported
-Anything else. If you miss a One-Jar feature and wish to contribute to its resurrection and subsequent 
-maintenance, please file an issue.
-
-### Versions
-Version number will carry forward from One-Jar's numbers, and 0.99 will be next, as soon as the WIP/TODO
-sections above are complete, followed by 1.0 after I fully cull things that won't be supported going 
-forward and can eliminate the old directory.
-
-## Disclaimer 
-Please note that I do not claim to have 100% fully understood Simon's code, so I may be breaking things 
-in subtle ways, but so far the fixes I have applied seem to have worked for me. Very happy to have 
-comments/suggestions. 
+Maven - contributions for a maven task are welcome. 
 
 ## Naming
 The name "uno-jar" is due to Simon's license which forbids endorsement of my code 

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ Maven - contributions for a maven task are welcome.
 ## Naming
 The name "uno-jar" is due to Simon's license which forbids endorsement of my code 
 with the trade marked name of his project (he trademarked One-JAR). Therefore aside
-from the discussion of differences from his wokr, attributions to his antecedent work 
+from the discussion of differences from his work, attributions to his antecedent work 
 and required licenses his name and the one-jar name will be removed from the project.

--- a/ant/build.gradle
+++ b/ant/build.gradle
@@ -18,7 +18,7 @@ configurations.all {
 }
 
 sourceCompatibility = 1.11
-version = '2.0.0-SNAPSHOT'
+version = '1.0.1'
 
 dependencies {
   implementation 'com.needhamsoftware.unojar:core:' + project.version

--- a/ant/build.gradle
+++ b/ant/build.gradle
@@ -18,7 +18,7 @@ configurations.all {
 }
 
 sourceCompatibility = 1.11
-version = '1.0.1'
+version = '2.0.0-SNAPSHOT'
 
 dependencies {
   implementation 'com.needhamsoftware.unojar:core:' + project.version

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 sourceCompatibility = 1.11
-version = '1.0.1'
+version = '2.0.0-SNAPSHOT'
 
 configurations.all {
   resolutionStrategy.cacheChangingModulesFor 0, 'seconds'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 sourceCompatibility = 1.11
-version = '2.0.0-SNAPSHOT'
+version = '1.0.1'
 
 configurations.all {
   resolutionStrategy.cacheChangingModulesFor 0, 'seconds'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,5 @@
 import java.text.SimpleDateFormat
 
-
 plugins {
   id 'java'
   id 'maven'
@@ -14,22 +13,68 @@ repositories {
   mavenCentral()
 }
 
-sourceCompatibility = 1.11
 version = '2.0.0-SNAPSHOT'
 
 configurations.all {
   resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 }
 
+dependencies {
+  testImplementation 'junit:junit:4.12'
+}
+
+sourceSets {
+  java9 {
+    java {
+      srcDirs = ['src/main/java9']
+    }
+  }
+
+  java11 {
+    java {
+      srcDirs = ['src/main/java11']
+    }
+  }
+}
+
+compileJava {
+  sourceCompatibility = 8
+  targetCompatibility = 8
+}
+
+compileJava9Java {
+  sourceCompatibility = 9
+  targetCompatibility = 9
+}
+
+compileJava11Java {
+  sourceCompatibility = 11
+  targetCompatibility = 11
+}
 
 dependencies {
-  testCompile 'junit:junit:4.12'
+  java9Implementation files(sourceSets.main.output.classesDirs) {
+    builtBy compileJava
+  }
+  java11Implementation files(sourceSets.main.output.classesDirs) {
+    builtBy compileJava
+  }
+  java11Implementation files(sourceSets.java9.output.classesDirs) {
+    builtBy compileJava9Java
+  }
 }
 
 jar {
   from('../') {
     include 'LICENSE.txt'
     include 'NOTICE.txt'
+  }
+
+  into('META-INF/versions/9') {
+    from sourceSets.java9.output
+  }
+  into('META-INF/versions/11') {
+    from sourceSets.java11.output
   }
 }
 
@@ -82,18 +127,20 @@ ext.snapshotRepo = 'https://oss.sonatype.org/content/repositories/snapshots'
 ext.testingRepo = 'file:///tmp/myRepo/'
 ext.uploadRepo = isRelease ? releaseRepo : (isSnapshot ? snapshotRepo : testingRepo)
 
-
 task uploadSnapshot(dependsOn: uploadArchives, group: 'upload') {}
 task uploadRelease(dependsOn: uploadArchives, group: 'upload') {}
 
 task sourcesJar(type: Jar, dependsOn: classes) {
   from sourceSets.main.allSource
+  from sourceSets.java9.allSource
+  from sourceSets.java11.allSource
+
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier = 'javadoc'
   from javadoc.destinationDir
-  archiveName = 'core-'+project.version+'-javadoc.jar'
+  archiveFileName = 'core-'+project.version+'-javadoc.jar'
 }
 
 artifacts {
@@ -130,7 +177,6 @@ signing {
   required { !isLocalVersion && gradle.taskGraph.hasTask('uploadArchives') }
   sign configurations.archives
 }
-
 
 ext.isLocalVersion = !version.endsWith("LOCAL")
 
@@ -201,9 +247,10 @@ def getManifestAttributes() {
   'Build-Revision': version + ' (' + gitDetails.gitHashFull + ')' + (gitDetails.clean ? '' : '(with uncommitted files)'),
   'Created-By': "Gradle ${gradle.gradleVersion}",
   'Build-Jdk': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
-  'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"]
+  'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}",
+  'Multi-Release' : 'true'
+  ]
 }
-
 
 def propOrDefault(String prop, String defaultVal) {
   return project.hasProperty(prop) ? project.getProperty(prop) : defaultVal
@@ -224,10 +271,3 @@ publishing {
 }
 
 publishMavenJavaPublicationToMavenLocal.dependsOn(sourcesJar)
-
-
-
-
-
-
-

--- a/core/src/main/java/com/needhamsoftware/unojar/Boot.java
+++ b/core/src/main/java/com/needhamsoftware/unojar/Boot.java
@@ -25,6 +25,8 @@ import java.util.jar.Attributes;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
+import static com.needhamsoftware.unojar.VersionSpecific.VERSION_SPECIFIC;
+
 /**
  * Run a java application which requires multiple support jars from inside
  * a single jar file.
@@ -40,9 +42,7 @@ import java.util.jar.Manifest;
  * @author simon@simontuffs.com (<a href="http://www.simontuffs.com">http://www.simontuffs.com</a>)
  */
 public class Boot {
-
   private final static Logger LOGGER = Logger.getLogger("Boot");
-
 
   public final static String ONE_JAR_CLASSLOADER = "Uno-Jar-Class-Loader";
   public final static String ONE_JAR_MAIN_CLASS = "Uno-Jar-Main-Class";
@@ -70,7 +70,7 @@ public class Boot {
       JarClassLoader.P_JAR_NAMES, "true:  Recorded classes are kept in directories corresponding to their jar names.\n" +
       "false: Recorded classes are flattened into a single directory.  \nDuplicates are ignored (first wins)",
       JarClassLoader.P_VERBOSE, "true:  Print verbose classloading information",
-      JarClassLoader.P_SILENT, "true:  Dont' print any classloading information",
+      JarClassLoader.P_SILENT, "true:  Don't print any classloading information",
       JarClassLoader.P_INFO, "true:  Print informative classloading information",
       P_STATISTICS, "true:  Shows statistics about the Uno-Jar Classloader",
       P_JARPATH, "Full path of the uno-Jar file being executed.  \nOnly needed if java.class.path does not contain the path to the jar, e.g. on Max OS/X.",
@@ -92,12 +92,10 @@ public class Boot {
   protected static long startTime = System.currentTimeMillis();
   protected static long endTime = 0;
 
-
   // Singleton loader.  This must not be changed once it is set, otherwise all
   // sorts of nasty class-cast exceptions will ensue.  Hence we control
   // access to it strongly.
   private static JarClassLoader loader = null;
-
 
   /**
    * This method provides access to the bootstrap Uno-Jar classloader which
@@ -353,13 +351,12 @@ public class Boot {
   }
 
   public static String pad(String indent, String string, int width) {
-    return indent + string + " ".repeat(Math.max(0, width - string.length()));
+    return VERSION_SPECIFIC.pad(indent, string, width);
   }
 
   public static String wrap(String indent, String string, int width) {
     String padding = pad(indent, "", width);
-    string = string.replaceAll("\n", "\n" + padding);
-    return string;
+    return string.replaceAll("\n", "\n" + padding);
   }
 
   public static String[] processArgs(String[] args) throws Exception {
@@ -430,5 +427,4 @@ public class Boot {
         }
     );
   }
-
 }

--- a/core/src/main/java/com/needhamsoftware/unojar/Handler.java
+++ b/core/src/main/java/com/needhamsoftware/unojar/Handler.java
@@ -28,7 +28,7 @@ public class Handler extends URLStreamHandler {
   public static String PROTOCOL = "onejar";
 
   /**
-   * @see java.net.URLStreamHandler#openConnection(java.net.URL)
+   * @see URLStreamHandler#openConnection(URL)
    */
   protected URLConnection openConnection(final URL u) {
     final String resource = u.getPath();
@@ -37,7 +37,7 @@ public class Handler extends URLStreamHandler {
       }
 
       public String getContentType() {
-        FileNameMap fileNameMap = java.net.URLConnection.getFileNameMap();
+        FileNameMap fileNameMap = URLConnection.getFileNameMap();
         String contentType = fileNameMap.getContentTypeFor(resource);
         if (contentType == null)
           contentType = "text/plain";

--- a/core/src/main/java/com/needhamsoftware/unojar/JarClassLoader.java
+++ b/core/src/main/java/com/needhamsoftware/unojar/JarClassLoader.java
@@ -35,7 +35,7 @@ import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.lang.StackWalker.Option.RETAIN_CLASS_REFERENCE;
+import static com.needhamsoftware.unojar.VersionSpecific.VERSION_SPECIFIC;
 
 /**
  * Loads classes from pre-defined locations inside the jar file containing this
@@ -114,8 +114,6 @@ public class JarClassLoader extends ClassLoader implements IProperties {
     public int mrVersion;
   }
 
-
-
   /*
    * Layout of the uno-jar.jar file
    *
@@ -186,7 +184,7 @@ public class JarClassLoader extends ClassLoader implements IProperties {
       // BUG-2833948
       // Delegate back into this classloader, use ThreadLocal to avoid recursion.
       externalClassLoader = AccessController.doPrivileged(
-          new PrivilegedAction<>() {
+          new PrivilegedAction<ClassLoader>() {
             public ClassLoader run() {
               return new URLClassLoader(urls, JarClassLoader.this) {
                 // Handle recursion for classes, and mutual recursion for resources.
@@ -246,7 +244,6 @@ public class JarClassLoader extends ClassLoader implements IProperties {
               };
             }
           });
-
     }
   }
 
@@ -286,7 +283,7 @@ public class JarClassLoader extends ClassLoader implements IProperties {
               Manifest m = mis.getManifest();
               // Is this a jar file with a manifest?
               if (m != null) {
-                mainClass = mis.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS);
+                mainClass = mis.getManifest().getMainAttributes().getValue(Name.MAIN_CLASS);
                 mainJar = $entry;
               }
             } else if (mainJar != null) {
@@ -352,7 +349,6 @@ public class JarClassLoader extends ClassLoader implements IProperties {
       ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
       loadBytes(entry, bais, jar, manifest);
     }
-
   }
 
   protected void loadBytes(JarEntry entry, InputStream is, String jar, Manifest man) throws IOException {
@@ -366,7 +362,7 @@ public class JarClassLoader extends ClassLoader implements IProperties {
     int index2 = entryName.lastIndexOf('/', index - 1);
     if (entryName.endsWith(CLASS) && index2 > -1) {
       String packageName = entryName.substring(0, index2).replace('/', '.');
-      if (getDefinedPackage(packageName) == null) {
+      if (VERSION_SPECIFIC.getDefinedPackage(this, packageName) == null) {
         // Defend against null manifest.
         if (man != null) {
           definePackage(packageName, man, urlFactory.getCodeBase(jar));
@@ -410,7 +406,6 @@ public class JarClassLoader extends ClassLoader implements IProperties {
 
       cacheBytes(entry, jar, man, entryName, baos);
       LOGGER.fine("cached bytes for entry name " + entryName);
-
     }
   }
 
@@ -531,7 +526,7 @@ public class JarClassLoader extends ClassLoader implements IProperties {
       if (i != -1) {
         String pkgname = name.substring(0, i);
         // Check if package already loaded.
-        Package pkg = getDefinedPackage(pkgname);
+        Package pkg = VERSION_SPECIFIC.getDefinedPackage(this, pkgname);
         Manifest man = bytecode.manifest;
         if (pkg != null) {
           // Package found, so check package sealing.
@@ -824,24 +819,9 @@ public class JarClassLoader extends ClassLoader implements IProperties {
     return false;
   }
 
-
   protected String getCaller() {
-    StackWalker walker = StackWalker.getInstance(RETAIN_CLASS_REFERENCE);
-    Optional<StackWalker.StackFrame> firstByteCode = walker.walk(s -> s.filter(f -> {
-      String caller = f.getClassName();
-      String cls = getByteCodeName(caller);
-      if (byteCode.get(cls) != null) {
-        return !caller.startsWith("com.needhamsoftware.unojar");
-      }
-      return false;
-    }).findFirst());
-    return firstByteCode.map(stackFrame -> getByteCodeName(stackFrame.getClassName())).orElse(null);
+    return VERSION_SPECIFIC.getCaller(byteCode.keySet());
   }
-
-  private String getByteCodeName(String className) {
-    return className.replace(".", "/") + ".class";
-  }
-
 
   public void setVerbose(boolean verbose) {
     if (verbose) {
@@ -1012,7 +992,6 @@ public class JarClassLoader extends ClassLoader implements IProperties {
     return binlib;
   };
 
-
   protected IBinlibResolver binlibResolver = defaultBinlibResolver;
 
   // Allow override for urlFactory
@@ -1075,7 +1054,6 @@ public class JarClassLoader extends ClassLoader implements IProperties {
       LOGGER.warning("unable to locate " + $resource + " due to " + mux);
     }
     return null;
-
   }
 
   protected Enumeration<URL> findResources(String name) throws IOException {
@@ -1093,7 +1071,7 @@ public class JarClassLoader extends ClassLoader implements IProperties {
       }
     }
     final Iterator<URL> ri = resources.iterator();
-    return new Enumeration<>() {
+    return new Enumeration<URL>() {
       public boolean hasMoreElements() {
         return ri.hasNext();
       }
@@ -1122,9 +1100,9 @@ public class JarClassLoader extends ClassLoader implements IProperties {
   }
 
   public String toString() {
-    return super.toString() + (getName() != null ? "(" + getName() + ")" : "");
+    String name = VERSION_SPECIFIC.getName(this);
+    return super.toString() + (name != null ? "(" + name + ")" : "");
   }
-
 
   /**
    * Preloader for {@link JarClassLoader#findTheLibrary(String, String)} to allow arch-specific native libraries
@@ -1204,7 +1182,6 @@ public class JarClassLoader extends ClassLoader implements IProperties {
         // Return null by default to search the java.library.path
         LOGGER.warning("Unable to load native library: " + e);
       }
-
     }
 
     return result;
@@ -1226,5 +1203,4 @@ public class JarClassLoader extends ClassLoader implements IProperties {
   public static boolean getProperty(String key) {
     return Boolean.parseBoolean(System.getProperty(key, "false"));
   }
-
 }

--- a/core/src/main/java/com/needhamsoftware/unojar/UnoJarFile.java
+++ b/core/src/main/java/com/needhamsoftware/unojar/UnoJarFile.java
@@ -63,7 +63,7 @@ public class UnoJarFile extends JarFile {
   public Enumeration<JarEntry> entries() {
     try {
       final JarInputStream is = new JarInputStream(super.getInputStream(wrappedJarFile));
-      return new Enumeration<>() {
+      return new Enumeration<JarEntry>() {
 
         protected JarEntry next;
 

--- a/core/src/main/java/com/needhamsoftware/unojar/VersionSpecific.java
+++ b/core/src/main/java/com/needhamsoftware/unojar/VersionSpecific.java
@@ -1,0 +1,5 @@
+package com.needhamsoftware.unojar;
+
+public class VersionSpecific {
+  public static final VersionSpecificExtensions VERSION_SPECIFIC = new VersionSpecificExtensions();
+}

--- a/core/src/main/java/com/needhamsoftware/unojar/VersionSpecificExtensions.java
+++ b/core/src/main/java/com/needhamsoftware/unojar/VersionSpecificExtensions.java
@@ -1,0 +1,30 @@
+package com.needhamsoftware.unojar;
+
+import java.util.Set;
+
+@SuppressWarnings({"deprecation"})
+public class VersionSpecificExtensions {
+  public String getName(ClassLoader classLoader) {
+    return null;
+  }
+
+  public Package getDefinedPackage(ClassLoader classLoader, String packageName) {
+    return new ClassLoader(classLoader) {
+      public Package f() {
+        return this.getPackage(packageName);
+      }
+    }.f();
+  }
+
+  public String getCaller(Set<String> byteCodeClasses) {
+    return null;
+  }
+
+  public String pad(String indent, String string, int width) {
+    StringBuilder res = new StringBuilder(indent + string);
+    for (int i = 0; i < Math.max(0, width - string.length()); i++) {
+      res.append(" ");
+    }
+    return res.toString();
+  }
+}

--- a/core/src/main/java/com/needhamsoftware/unojar/VersionSpecificExtensions.java
+++ b/core/src/main/java/com/needhamsoftware/unojar/VersionSpecificExtensions.java
@@ -17,6 +17,14 @@ public class VersionSpecificExtensions {
   }
 
   public String getCaller(Set<String> byteCodeClasses) {
+    for (StackTraceElement stackTraceElement : new Throwable().getStackTrace()) {
+      String caller = stackTraceElement.getClassName();
+      String cls = getByteCodeName(caller);
+      if (byteCodeClasses.contains(cls) && !caller.startsWith("com.needhamsoftware.unojar")) {
+        return cls;
+      }
+    }
+
     return null;
   }
 
@@ -26,5 +34,9 @@ public class VersionSpecificExtensions {
       res.append(" ");
     }
     return res.toString();
+  }
+
+  protected static String getByteCodeName(String className) {
+    return className.replace(".", "/") + ".class";
   }
 }

--- a/core/src/main/java11/com/needhamsoftware/unojar/Java11SpecificExtensions.java
+++ b/core/src/main/java11/com/needhamsoftware/unojar/Java11SpecificExtensions.java
@@ -1,0 +1,8 @@
+package com.needhamsoftware.unojar;
+
+public class Java11SpecificExtensions extends Java9SpecificExtensions {
+  @Override
+  public String pad(String indent, String string, int width) {
+    return indent + string + " ".repeat(Math.max(0, width - string.length()));
+  }
+}

--- a/core/src/main/java11/com/needhamsoftware/unojar/VersionSpecific.java
+++ b/core/src/main/java11/com/needhamsoftware/unojar/VersionSpecific.java
@@ -1,0 +1,6 @@
+package com.needhamsoftware.unojar;
+
+@SuppressWarnings("unused")
+public class VersionSpecific {
+  public static final VersionSpecificExtensions VERSION_SPECIFIC = new Java11SpecificExtensions();
+}

--- a/core/src/main/java9/com/needhamsoftware/unojar/Java9SpecificExtensions.java
+++ b/core/src/main/java9/com/needhamsoftware/unojar/Java9SpecificExtensions.java
@@ -1,0 +1,33 @@
+package com.needhamsoftware.unojar;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static java.lang.StackWalker.Option.RETAIN_CLASS_REFERENCE;
+
+public class Java9SpecificExtensions extends VersionSpecificExtensions {
+  @Override
+  public String getName(ClassLoader classLoader) {
+        return classLoader.getName();
+    }
+
+  @Override
+  public Package getDefinedPackage(ClassLoader classLoader, String packageName) {
+    return classLoader.getDefinedPackage(packageName);
+  }
+
+  @Override
+  public String getCaller(Set<String> byteCodeClasses) {
+    StackWalker walker = StackWalker.getInstance(RETAIN_CLASS_REFERENCE);
+    Optional<StackWalker.StackFrame> firstByteCode = walker.walk(s -> s.filter(f -> {
+      String caller = f.getClassName();
+      String cls = getByteCodeName(caller);
+      return byteCodeClasses.contains(cls) && !caller.startsWith("com.needhamsoftware.unojar");
+    }).findFirst());
+    return firstByteCode.map(stackFrame -> getByteCodeName(stackFrame.getClassName())).orElse(null);
+  }
+
+  private static String getByteCodeName(String className) {
+        return className.replace(".", "/") + ".class";
+    }
+}

--- a/core/src/main/java9/com/needhamsoftware/unojar/Java9SpecificExtensions.java
+++ b/core/src/main/java9/com/needhamsoftware/unojar/Java9SpecificExtensions.java
@@ -26,8 +26,4 @@ public class Java9SpecificExtensions extends VersionSpecificExtensions {
     }).findFirst());
     return firstByteCode.map(stackFrame -> getByteCodeName(stackFrame.getClassName())).orElse(null);
   }
-
-  private static String getByteCodeName(String className) {
-        return className.replace(".", "/") + ".class";
-    }
 }

--- a/core/src/main/java9/com/needhamsoftware/unojar/VersionSpecific.java
+++ b/core/src/main/java9/com/needhamsoftware/unojar/VersionSpecific.java
@@ -1,0 +1,6 @@
+package com.needhamsoftware.unojar;
+
+@SuppressWarnings("unused")
+public class VersionSpecific {
+  public static final VersionSpecificExtensions VERSION_SPECIFIC = new Java9SpecificExtensions();
+}

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -1,11 +1,14 @@
+import java.text.SimpleDateFormat
+
 plugins {
   id 'groovy'
   id 'maven-publish'
   id 'java-gradle-plugin'
   id 'com.gradle.plugin-publish' version '0.11.0'
+  id 'com.palantir.git-version' version '0.12.2'
 }
 
-version = '2.0.0-SNAPSHOT'
+version = '1.0.1'
 
 configurations.all {
   resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
@@ -31,6 +34,22 @@ gradlePlugin {
       implementationClass = 'com.needhamsoftware.unojar.gradle.UnoJarPlugin'
     }
   }
+}
+jar.manifest.attributes getManifestAttributes()
+
+@SuppressWarnings("GroovyAssignabilityCheck")
+def getManifestAttributes() {
+  def gitDetails = versionDetails();
+  return [
+      'Implementation-Version': version,
+      'Build-Tool': "Gradle ${gradle.gradleVersion}",
+      'Main-Class': "com.needhamsoftware.unojar.Boot",
+      'Built-By': System.properties['user.name'],
+      'Build-Timestamp': new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
+      'Build-Revision': version + ' (' + gitDetails.gitHashFull + ')' + (gitDetails.clean ? '' : '(with uncommitted files)'),
+      'Created-By': "Gradle ${gradle.gradleVersion}",
+      'Build-Jdk': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+      'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"]
 }
 
 publishing {

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'com.palantir.git-version' version '0.12.2'
 }
 
-version = '1.0.1'
+version = '2.0.0-SNAPSHOT'
 
 configurations.all {
   resolutionStrategy.cacheChangingModulesFor 0, 'seconds'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -13,10 +13,10 @@ buildscript {
 
 plugins {
   id 'java'
-  id 'com.needhamsoftware.unojar' version '1.0.1'
+  id 'com.needhamsoftware.unojar' version '2.0.0-SNAPSHOT'
 }
 
-version = '1.0.1'
+version = '2.0.0-SNAPSHOT'
 
 sourceCompatibility = 1.11
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -13,10 +13,10 @@ buildscript {
 
 plugins {
   id 'java'
-  id 'com.needhamsoftware.unojar' version '1.0-SNAPSHOT'
+  id 'com.needhamsoftware.unojar' version '1.0.1'
 }
 
-version = '2.0.0-SNAPSHOT'
+version = '1.0.1'
 
 sourceCompatibility = 1.11
 


### PR DESCRIPTION
Rebuild core as [Multi-Release JAR](https://openjdk.java.net/jeps/238):
extract Java9 & Java11 specific API to separate source sets;
remove syntax sugar so that code become compilable in Java8;

Also some minor refactoring: fix typos, remove extra empty lines, redundant fully-qualified class names;
Replace some deprecated Gradle properties with modern ones